### PR TITLE
Fix libcamera build

### DIFF
--- a/overlays/libcamera.nix
+++ b/overlays/libcamera.nix
@@ -3,8 +3,7 @@
 , libpisp-src
 , ...
 }:
-final: prev:
-{
+final: prev: {
   # A recent known working version of rpicam-apps
   libcamera-apps =
     final.callPackage ./rpicam-apps.nix { inherit rpicam-apps-src; };
@@ -22,7 +21,7 @@ final: prev:
   };
 
   libcamera = prev.libcamera.overrideAttrs (old: {
-    version = "0.2.0";
+    version = "0.3.0";
     src = libcamera-src;
     buildInputs = old.buildInputs ++ (with final; [
       libpisp openssl libtiff
@@ -30,9 +29,11 @@ final: prev:
         python3-gnutls pybind11 pyyaml ply
       ]))
       libglibutil gst_all_1.gst-plugins-base
-      
     ]);
     patches = [ ];
+    postPatch = ''
+      patchShebangs src/py/ utils/
+    '';
     mesonFlags = [
       "--buildtype=release"
       "-Dpipelines=rpi/vc4,rpi/pisp"

--- a/overlays/rpicam-apps.nix
+++ b/overlays/rpicam-apps.nix
@@ -1,22 +1,25 @@
-{ libcamera-apps-src, lib, pkgs, stdenv }:
-stdenv.mkDerivation rec {
+{ rpicam-apps-src, lib, pkgs, stdenv }:
+
+stdenv.mkDerivation {
   pname = "libcamera-apps";
   version = "v1.5.0";
 
-  src = libcamera-apps-src;
+  src = rpicam-apps-src;
 
   nativeBuildInputs = with pkgs; [ meson pkg-config ];
-  buildInputs = with pkgs; [ libjpeg libtiff libcamera libepoxy boost libexif libpng ninja ];
+  buildInputs = with pkgs; [ libjpeg libtiff libcamera libepoxy boost libexif libpng ffmpeg libdrm ninja ];
   mesonFlags = [
-    "-Denable_qt=false"
-    "-Denable_opencv=false"
-    "-Denable_tflite=false"
-    "-Denable_drm=true"
+    "-Denable_qt=disabled"
+    "-Denable_opencv=disabled"
+    "-Denable_tflite=disabled"
+    "-Denable_egl=disabled"
+    "-Denable_hailo=disabled"
+    "-Denable_drm=enabled"
   ];
   # Meson is no longer able to pick up Boost automatically.
   # https://github.com/NixOS/nixpkgs/issues/86131
-  BOOST_INCLUDEDIR = "${lib.getDev boost}/include";
-  BOOST_LIBRARYDIR = "${lib.getLib boost}/lib";
+  BOOST_INCLUDEDIR = "${lib.getDev pkgs.boost}/include";
+  BOOST_LIBRARYDIR = "${lib.getLib pkgs.boost}/lib";
 
   meta = with lib; {
     description = "Userland tools interfacing with Raspberry Pi cameras";


### PR DESCRIPTION
This backports the `postPatch` change from nixpkgs to the libcamera overlay so the build doesn't break, and also changes the rpicam-apps overlay so it builds properly now.

The version in the libcamera overlay has been fixed to match upstream.

Note that whilst this now builds for me, actually trying to use a HQ cam segfaults.