### PR TITLE
libcamera: add flake-check to binary-cache via buildbot

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -80,6 +80,7 @@
         {
           example-sd-image = self.nixosConfigurations.rpi-example.config.system.build.sdImage;
           firmware = pinned.raspberrypifw;
+          libcamera = pinned.libcamera;
           wireless-firmware = pinned.raspberrypiWirelessFirmware;
           uboot-rpi-arm64 = pinned.uboot-rpi-arm64;
         } // kernels;


### PR DESCRIPTION
As discussed in https://github.com/nix-community/raspberry-pi-nix/pull/42#issuecomment-2292221344 adding a check for libcamera to distribute it via cachix.