### PR TITLE
Update 6.6 kernel & firmware

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -101,16 +101,16 @@
     "rpi-firmware-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1716978780,
-        "narHash": "sha256-KsCo7ZG6vKstxRyFljZtbQvnDSqiAPdUza32xTY/tlA=",
+        "lastModified": 1723556646,
+        "narHash": "sha256-EApB8gKBpQxiDbgecIGzYjeYU+tHGP+G9pTubY/7oVw=",
         "owner": "raspberrypi",
         "repo": "firmware",
-        "rev": "3590de0c181d433af368a95f15bc480bdaff8b47",
+        "rev": "6b029c7772b5d29a50a07c477a808a7effb0a373",
         "type": "github"
       },
       "original": {
         "owner": "raspberrypi",
-        "ref": "1.20240529",
+        "ref": "master",
         "repo": "firmware",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -59,7 +59,7 @@
         "rpi-firmware-nonfree-src": "rpi-firmware-nonfree-src",
         "rpi-firmware-src": "rpi-firmware-src",
         "rpi-linux-6_10_0-rc5-src": "rpi-linux-6_10_0-rc5-src",
-        "rpi-linux-6_6_31-src": "rpi-linux-6_6_31-src",
+        "rpi-linux-6_6_y-src": "rpi-linux-6_6_y-src",
         "rpicam-apps-src": "rpicam-apps-src",
         "u-boot-src": "u-boot-src"
       }
@@ -132,19 +132,19 @@
         "type": "github"
       }
     },
-    "rpi-linux-6_6_31-src": {
+    "rpi-linux-6_6_y-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1716545726,
-        "narHash": "sha256-UWUTeCpEN7dlFSQjog6S3HyEWCCnaqiUqV5KxCjYink=",
+        "lastModified": 1723841613,
+        "narHash": "sha256-T4SRDLe7IyFlf3cbkCvoNVizNmgAYXx+c+IdJ0toka0=",
         "owner": "raspberrypi",
         "repo": "linux",
-        "rev": "c1432b4bae5b6582f4d32ba381459f33c34d1424",
+        "rev": "15ca476264094b25d0a210109a061192a468117b",
         "type": "github"
       },
       "original": {
         "owner": "raspberrypi",
-        "ref": "stable_20240529",
+        "ref": "rpi-6.6.y",
         "repo": "linux",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -84,11 +84,11 @@
     "rpi-firmware-nonfree-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1708967191,
-        "narHash": "sha256-BGq0+cr+xBRwQM/LqiQuRWuZpQsKM5jfcrNCqWMuVzM=",
+        "lastModified": 1723266537,
+        "narHash": "sha256-T7eTKXqY9cxEMdab8Snda4CEOrEihy5uOhA6Fy+Mhnw=",
         "owner": "RPi-Distro",
         "repo": "firmware-nonfree",
-        "rev": "223ccf3a3ddb11b3ea829749fbbba4d65b380897",
+        "rev": "4b356e134e8333d073bd3802d767a825adec3807",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
     };
     rpi-firmware-src = {
       flake = false;
-      url = "github:raspberrypi/firmware/1.20240529";
+      url = "github:raspberrypi/firmware/master";
     };
     rpi-firmware-nonfree-src = {
       flake = false;

--- a/flake.nix
+++ b/flake.nix
@@ -7,9 +7,9 @@
       flake = false;
       url = "https://ftp.denx.de/pub/u-boot/u-boot-2024.04.tar.bz2";
     };
-    rpi-linux-6_6_31-src = {
+    rpi-linux-6_6_y-src = {
       flake = false;
-      url = "github:raspberrypi/linux/stable_20240529";
+      url = "github:raspberrypi/linux/rpi-6.6.y";
     };
     rpi-linux-6_10_0-rc5-src = {
       flake = false;

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -1,5 +1,5 @@
 { u-boot-src
-, rpi-linux-6_6_31-src
+, rpi-linux-6_6_y-src
 , rpi-linux-6_10_0-rc5-src
 , rpi-firmware-src
 , rpi-firmware-nonfree-src
@@ -9,26 +9,8 @@
 final: prev:
 let
   versions = {
-    v6_6_31 = {
-      src = rpi-linux-6_6_31-src;
-      patches = [
-        # Fix compilation errors due to incomplete patch backport.
-        # https://github.com/raspberrypi/linux/pull/6223
-        {
-          name = "gpio-pwm_-_pwm_apply_might_sleep.patch";
-          patch = final.fetchpatch {
-            url = "https://github.com/peat-psuwit/rpi-linux/commit/879f34b88c60dd59765caa30576cb5bfb8e73c56.patch";
-            hash = "sha256-HlOkM9EFmlzOebCGoj7lNV5hc0wMjhaBFFZvaRCI0lI=";
-          };
-        }
-        {
-          name = "ir-rx51_-_pwm_apply_might_sleep.patch";
-          patch = final.fetchpatch {
-            url = "https://github.com/peat-psuwit/rpi-linux/commit/23431052d2dce8084b72e399fce82b05d86b847f.patch";
-            hash = "sha256-UDX/BJCJG0WVndP/6PbPK+AZsfU3vVxDCrpn1kb1kqE=";
-          };
-        }
-      ];
+    v6_6_45 = {
+      src = rpi-linux-6_6_y-src;
     };
     v6_10_0-rc5 = {
       src = rpi-linux-6_10_0-rc5-src;
@@ -140,7 +122,7 @@ in
   # rpi kernels and firmware are available at
   # `pkgs.rpi-kernels.<VERSION>.<BOARD>'. 
   #
-  # For example: `pkgs.rpi-kernels.v6_6_31.bcm2712'
+  # For example: `pkgs.rpi-kernels.v6_6_45.bcm2712'
   rpi-kernels = rpi-kernels (
     final.lib.cartesianProduct
       { board = boards; version = (builtins.attrNames versions); }

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -105,7 +105,7 @@ in
   compressFirmwareZstd = x: x;
 
   # provide generic rpi arm64 u-boot
-  uboot-rpi-arm64 = final.buildUBoot rec {
+  uboot-rpi-arm64 = final.buildUBoot {
     defconfig = "rpi_arm64_defconfig";
     extraMeta.platforms = [ "aarch64-linux" ];
     filesToInstall = [ "u-boot.bin" ];

--- a/rpi/default.nix
+++ b/rpi/default.nix
@@ -13,7 +13,7 @@ in
   options = with lib; {
     raspberry-pi-nix = {
       kernel-version = mkOption {
-        default = "v6_6_31";
+        default = "v6_6_45";
         type = types.str;
         description = "Kernel version to build.";
       };


### PR DESCRIPTION
Updated the kernel source to the rpi-6.6.y branch (6.6.45 as of now) since upstream is not tagging releases. This is also what the Arch Linux ARM project is doing, see https://archlinuxarm.org/packages/aarch64/linux-rpi.

Also the firmware packages have been updated.