### PR TITLE
migration: fix stray quote

### DIFF
--- a/rpi/default.nix
+++ b/rpi/default.nix
@@ -121,7 +121,7 @@ in
                     touch "$STATE_DIRECTORY/uboot-migration-in-progress"
                     cp "$UBOOT" "$TMPFILE"
                     mv -T "$TMPFILE" "$TARGET_FIRMWARE_DIR/u-boot-rpi-arm64.bin"
-                    echo "${builtins.toString cfg.uboot.package}" " > "$STATE_DIRECTORY/uboot-version"
+                    echo "${builtins.toString cfg.uboot.package}" > "$STATE_DIRECTORY/uboot-version"
                     rm "$STATE_DIRECTORY/uboot-migration-in-progress"
                   }
                 ''}


### PR DESCRIPTION
Introduced in a993f0c but likely flew under the radar due to eval caching?