### PR TITLE
uboot: fix a pkgs.uboot use in the migration script i didnt catch

### DIFF
--- a/rpi/default.nix
+++ b/rpi/default.nix
@@ -101,7 +101,6 @@ in
                 TARGET_FIRMWARE_DIR="${firmware-path}"
                 TARGET_OVERLAYS_DIR="$TARGET_FIRMWARE_DIR/overlays"
                 TMPFILE="$TARGET_FIRMWARE_DIR/tmp"
-                UBOOT="${cfg.uboot.package}/u-boot.bin"
                 KERNEL="${kernel}/Image"
                 SHOULD_UBOOT=${if cfg.uboot.enable then "1" else "0"}
                 SRC_FIRMWARE_DIR="${pkgs.raspberrypifw}/share/raspberrypi/boot"

--- a/rpi/default.nix
+++ b/rpi/default.nix
@@ -114,7 +114,7 @@ in
                 CONFIG="${config.hardware.raspberry-pi.config-output}"
 
                 ${lib.strings.optionalString cfg.uboot.enable ''
-                  UBOOT="${pkgs.uboot-rpi-arm64}/u-boot.bin"
+                  UBOOT="${cfg.uboot.package}/u-boot.bin"
 
                   migrate_uboot() {
                     echo "migrating uboot"


### PR DESCRIPTION
My bad, missed that one when i rebased my original commit and since it affected the migration script it passed my "flash and see if right logo was there" check.