### PR TITLE
Allow empty base dtparams

### DIFF
--- a/rpi/config.nix
+++ b/rpi/config.nix
@@ -93,7 +93,7 @@ in
                 };
               };
               base-dt-params = lib.mkOption {
-                type = with lib.types; attrsOf (submodule rpi-config-param);
+                type = with lib.types; attrsOf (submodule dt-param);
                 default = { };
                 example = {
                   i2c = {


### PR DESCRIPTION
This allows one to set options such as `dtparam=uart0`, which was not being allowed.