### PR TITLE
Fix `rpicam-apps` and `libpisp` overlays  

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,8 @@
     };
     rpicam-apps-src = {
       flake = false;
-      url = "github:raspberrypi/rpicam-apps/v1.5.2";
+      #url = "github:raspberrypi/rpicam-apps/v1.5.2";
+      url = "github:raspberrypi/rpicam-apps/v1.5.1";
     };
     libcamera-src = {
       flake = false;

--- a/overlays/libcamera.nix
+++ b/overlays/libcamera.nix
@@ -18,6 +18,12 @@ final: prev: {
     # https://github.com/NixOS/nixpkgs/issues/86131
     BOOST_INCLUDEDIR = "${prev.lib.getDev final.boost}/include";
     BOOST_LIBRARYDIR = "${prev.lib.getLib final.boost}/lib";
+
+    postInstall = ''
+      ls -l
+      mkdir -p $out/lib/libpisp/backend
+      cp src/libpisp/backend/backend_default_config.json $out/lib/libpisp/backend/backend_default_config.json
+    '';
   };
 
   libcamera = prev.libcamera.overrideAttrs (old: {

--- a/overlays/rpicam-apps.nix
+++ b/overlays/rpicam-apps.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation {
 
   src = rpicam-apps-src;
 
-  nativeBuildInputs = with pkgs; [ meson pkg-config ];
+  nativeBuildInputs = with pkgs; [ meson pkg-config makeWrapper ];
   buildInputs = with pkgs; [ libjpeg libtiff libcamera libepoxy boost libexif libpng ffmpeg libdrm ninja ];
   mesonFlags = [
     "-Denable_qt=disabled"
@@ -20,6 +20,23 @@ stdenv.mkDerivation {
   # https://github.com/NixOS/nixpkgs/issues/86131
   BOOST_INCLUDEDIR = "${lib.getDev pkgs.boost}/include";
   BOOST_LIBRARYDIR = "${lib.getLib pkgs.boost}/lib";
+
+  postFixup = ''
+    wrapProgram $out/bin/rpicam-hello \
+      --set LIBCAMERA_IPA_PROXY_PATH ${pkgs.libcamera}/libexec/libcamera
+
+    wrapProgram $out/bin/rpicam-raw \
+      --set LIBCAMERA_IPA_PROXY_PATH ${pkgs.libcamera}/libexec/libcamera
+
+    wrapProgram $out/bin/rpicam-vid \
+      --set LIBCAMERA_IPA_PROXY_PATH ${pkgs.libcamera}/libexec/libcamera
+
+    wrapProgram $out/bin/rpicam-jpeg \
+      --set LIBCAMERA_IPA_PROXY_PATH ${pkgs.libcamera}/libexec/libcamera
+
+    wrapProgram $out/bin/rpicam-still \
+      --set LIBCAMERA_IPA_PROXY_PATH ${pkgs.libcamera}/libexec/libcamera
+  '';
 
   meta = with lib; {
     description = "Userland tools interfacing with Raspberry Pi cameras";


### PR DESCRIPTION
Hello,

I finally got the camera (IMX708) to work with this project, and this PR are the changes I did to get it to a working state (mostly specifying paths).

I downgraded `rpicam-apps` to 1.5.1 since 1.5.2 introduces IMX500 which needs `libcamera` 3.2.0 and I couldn't get it to compile.

There's a chance that this fixes #40.