### PR TITLE
Fix "resizing" wrong partition when having two disks

### DIFF
--- a/sd-image/sd-image.nix
+++ b/sd-image/sd-image.nix
@@ -248,7 +248,7 @@ in
         # Figure out device names for the boot device and root filesystem.
         rootPart=$(${pkgs.util-linux}/bin/findmnt -n -o SOURCE /)
         bootDevice=$(lsblk -npo PKNAME $rootPart)
-        partNum=$(lsblk -npo MAJ:MIN $rootPart | ${pkgs.gawk}/bin/awk -F: '{print $2}')
+        partNum=$(lsblk -npo PARTN $rootPart)
 
         # Resize the root partition and the filesystem to fit the disk
         echo ",+," | sfdisk -N$partNum --no-reread $bootDevice


### PR DESCRIPTION
Hi!

I discovered that the `postBootCommands` script didn't work under certain circumstances. I created an image with the following filesystem setup:
```
...

    fileSystems = {
      "/boot/firmware" = {
        label = config.raspberry-pi-nix.firmware-partition-label;
        device = "/dev/disk/by-label/${config.raspberry-pi-nix.firmware-partition-label}";
        fsType = "vfat";
      };
      "/" = {
        label = "NIXOS_SD";
        device = "/dev/disk/by-label/NIXOS_SD";
        fsType = "ext4";
      };
      "/foo/bar" = {
        label = "FOO_BAR";
        device = "/dev/disk/by-label/FOO_BAR";
        fsType = "ext4";
      };
    };

...
```
On the Pi I use a dual NVME HAT. One disk was flashed with the disk image and the other disk was previously prepared with an ext4 FS and labeled with `FOO_BAR`.
After booting the Pi I checked the devices with `lsblk` and found out that the disk I flashed with the created image was `nvme1n1` instead of `nvme0n1` and the additional disk was `nvme0n1`. `lsblk` output was something like this (from memory):
```
NAME                                          MAJ:MIN RM   SIZE RO TYPE  MOUNTPOINTS
nvme0n1                                       259:0    0 953.9G  0 disk  
└─nvme0n1p1                                   259:1    0 953.9G  0 part  /foo/bar
nvme1n1                                       259:2    0 238.5G  0 disk
├─nvme1n1p1                                   259:3    0   128M  0 part  /boot/firmware
├─nvme1n1p2                                   259:4    0   3.1G  0 part  /nix/store
|                                                                        /
├─nvme1n1p3                                   259:5    0     7M  0 part
└─nvme1n1p4                                   259:6    0   234G  0 part
```

The `postBootCommands` script created partition 4 (and 3) because it takes `MAJ:MIN` column to determine partition number, which is 4 in this case, but should be 2.
This happens when another disk is indexed before the flashed one.
After changing the script by using `PARTN` column of `lsblk` output, it looks as expected:
```
NAME                                          MAJ:MIN RM   SIZE RO TYPE  MOUNTPOINTS
nvme0n1                                       259:0    0 953.9G  0 disk  
└─nvme0n1p1                                   259:1    0 953.9G  0 part  /foo/bar
nvme1n1                                       259:2    0 238.5G  0 disk
├─nvme1n1p1                                   259:3    0   128M  0 part  /boot/firmware
└─nvme1n1p2                                   259:4    0 238.3G  0 part  /nix/store
                                                                         /
```