### PR TITLE
Update kernel from 6.6.54 to 6.6.67

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -59,7 +59,7 @@
         "rpi-firmware-nonfree-src": "rpi-firmware-nonfree-src",
         "rpi-firmware-src": "rpi-firmware-src",
         "rpi-linux-6_10_12-src": "rpi-linux-6_10_12-src",
-        "rpi-linux-6_6_54-src": "rpi-linux-6_6_54-src",
+        "rpi-linux-6_6_67-src": "rpi-linux-6_6_67-src",
         "rpicam-apps-src": "rpicam-apps-src",
         "u-boot-src": "u-boot-src"
       }
@@ -132,14 +132,14 @@
         "type": "github"
       }
     },
-    "rpi-linux-6_6_54-src": {
+    "rpi-linux-6_6_67-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1728155174,
-        "narHash": "sha256-/8RjW35XQMnshjAE4Ey8j3oWzE2GOntnBYY6PlvZGhs=",
+        "lastModified": 1734790986,
+        "narHash": "sha256-q9swM2TmmuzbUuQnbLZk5PseKWD7/SNPwtth6bpGIqE=",
         "owner": "raspberrypi",
         "repo": "linux",
-        "rev": "12f0f28db3afe451a81a34c5a444f6841c10067c",
+        "rev": "811ff707533bcd67cdcd368bbd46223082009b12",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
       flake = false;
       url = "https://ftp.denx.de/pub/u-boot/u-boot-2024.07.tar.bz2";
     };
-    rpi-linux-6_6_54-src = {
+    rpi-linux-6_6_67-src = {
       flake = false;
       url = "github:raspberrypi/linux/rpi-6.6.y";
     };

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -1,5 +1,5 @@
 { u-boot-src
-, rpi-linux-6_6_54-src
+, rpi-linux-6_6_67-src
 , rpi-linux-6_10_12-src
 , rpi-firmware-src
 , rpi-firmware-nonfree-src
@@ -9,7 +9,7 @@
 final: prev:
 let
   versions = {
-    v6_6_54.src = rpi-linux-6_6_54-src;
+    v6_6_67.src = rpi-linux-6_6_67-src;
     v6_10_12 = {
       src = rpi-linux-6_10_12-src;
       patches = [
@@ -116,7 +116,7 @@ in
   # rpi kernels and firmware are available at
   # `pkgs.rpi-kernels.<VERSION>.<BOARD>'. 
   #
-  # For example: `pkgs.rpi-kernels.v6_6_54.bcm2712'
+  # For example: `pkgs.rpi-kernels.v6_6_67.bcm2712'
   rpi-kernels = rpi-kernels (
     final.lib.cartesianProduct
       { board = boards; version = (builtins.attrNames versions); }

--- a/rpi/default.nix
+++ b/rpi/default.nix
@@ -14,7 +14,7 @@ in
   options = with lib; {
     raspberry-pi-nix = {
       kernel-version = mkOption {
-        default = "v6_6_54";
+        default = "v6_6_67";
         type = types.str;
         description = "Kernel version to build.";
       };


### PR DESCRIPTION
This change updates the default kernel from `6.6.54` to `6.6.67`.

This is the latest release in the `rpi-6.6.y` branch[^1], as well as the latest patch release for the `6.6` upstream kernel[^2].

I couldn't find any guidelines on kernel updates. However, given that the currently used kernel version, `6.6.54`, is already newer than the kernel version in the latest release of Raspberry Pi OS[^3], `6.6.51`, I think it's safe to assume that the policy is to keep the kernel up-to-date with what's in `raspberrypi/linux` rather than released versions of Raspberry Pi OS.

[^1]: https://github.com/raspberrypi/linux/commit/811ff707533bcd67cdcd368bbd46223082009b12
[^2]: https://kernel.org/
[^3]: https://downloads.raspberrypi.com/raspios_arm64/release_notes.txt