### PR TITLE
Drop kernel 6.10.12 in favour of 6.12.6

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -58,7 +58,7 @@
         "rpi-bluez-firmware-src": "rpi-bluez-firmware-src",
         "rpi-firmware-nonfree-src": "rpi-firmware-nonfree-src",
         "rpi-firmware-src": "rpi-firmware-src",
-        "rpi-linux-6_10_12-src": "rpi-linux-6_10_12-src",
+        "rpi-linux-6_12_11-src": "rpi-linux-6_12_11-src",
         "rpi-linux-6_6_67-src": "rpi-linux-6_6_67-src",
         "rpi-linux-stable-src": "rpi-linux-stable-src",
         "rpicam-apps-src": "rpicam-apps-src",
@@ -116,19 +116,19 @@
         "type": "github"
       }
     },
-    "rpi-linux-6_10_12-src": {
+    "rpi-linux-6_12_11-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1728305462,
-        "narHash": "sha256-LtvNmGD1D5YYv+C9xxxddAeHw69o3OX/H9M7F663L74=",
+        "lastModified": 1738149451,
+        "narHash": "sha256-NGmZcaC2vlewTEV/p0z2+6PWnHB229dkGui45kI8HOE=",
         "owner": "raspberrypi",
         "repo": "linux",
-        "rev": "26ee50d56618c2d98100b1bc672fd201aed4d00f",
+        "rev": "fab655ee33e6d647da5996c5548cfd7d43447a53",
         "type": "github"
       },
       "original": {
         "owner": "raspberrypi",
-        "ref": "rpi-6.10.y",
+        "ref": "rpi-6.12.y",
         "repo": "linux",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -15,9 +15,9 @@
       flake = false;
       url = "github:raspberrypi/linux/rpi-6.6.y";
     };
-    rpi-linux-6_10_12-src = {
+    rpi-linux-6_12_11-src = {
       flake = false;
-      url = "github:raspberrypi/linux/rpi-6.10.y";
+      url = "github:raspberrypi/linux/rpi-6.12.y";
     };
     rpi-firmware-src = {
       flake = false;

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -1,7 +1,7 @@
 { u-boot-src
 , rpi-linux-stable-src
 , rpi-linux-6_6_67-src
-, rpi-linux-6_10_12-src
+, rpi-linux-6_12_11-src
 , rpi-firmware-src
 , rpi-firmware-nonfree-src
 , rpi-bluez-firmware-src
@@ -12,8 +12,8 @@ let
   versions = {
     v6_6_51.src = rpi-linux-stable-src;
     v6_6_67.src = rpi-linux-6_6_67-src;
-    v6_10_12 = {
-      src = rpi-linux-6_10_12-src;
+    v6_12_11 = {
+      src = rpi-linux-6_12_11-src;
       patches = [
         {
           name = "remove-readme-target.patch";


### PR DESCRIPTION
The `6.10` series kernel had it's last release of `6.10.14` on 10th October, and has now reached end-of-life[^1]. The `6.12` series kernel is currently the latest stable version, and the newest LTS release [^2].

[^1]: https://endoflife.date/linux
[^2]: https://www.kernel.org/category/releases.html