### PR TITLE
Add raspberry-pi-nix.serial-console.enable option

### DIFF
--- a/rpi/default.nix
+++ b/rpi/default.nix
@@ -77,6 +77,18 @@ in
 
         package = mkPackageOption pkgs "uboot-rpi-arm64" { };
       };
+      serial-console = {
+        enable = mkOption {
+          default = true;
+          type = types.bool;
+          description = ''
+            Whether to enable a console on serial0.
+
+            Corresponds with raspi-config's setting
+            "Would you like a login shell to be accessible over serial?"
+          '';
+        };
+      };
     };
   };
 
@@ -319,11 +331,14 @@ in
     boot = {
       kernelParams =
         if cfg.uboot.enable then [ ]
-        else [
-          "console=tty1"
-          # https://github.com/raspberrypi/firmware/issues/1539#issuecomment-784498108
-          "console=serial0,115200n8"
-          "init=/sbin/init"
+        else builtins.concatLists [
+          [ "console=tty1" ]
+          (if cfg.serial-console.enable then [
+            # https://github.com/raspberrypi/firmware/issues/1539#issuecomment-784498108
+            "console=serial0,115200n8"
+          ] else [ ]
+          )
+          [ "init=/sbin/init" ]
         ];
       initrd = {
         availableKernelModules = [


### PR DESCRIPTION
This option controls whether to enable a console over serial0. Output on this console can confuse devices connected to the GPIO pins. For example, https://adapter.ebusd.eu/v5/raspberrypi.en#configuration-with-raspberry-pi-os requires the serial0 console to be disabled.

The effect of this option is to conditionally include the `console=serial0,115200n8` kernel parameter.
The default is to include this kernel parameter, so this option does not influence existing configurations.