### PR TITLE
Ignore kernel config errors

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -63,6 +63,7 @@ let
         features.efiBootStub = false;
         kernelPatches =
           if kernel ? "patches" then kernel.patches else [ ];
+        ignoreConfigErrors = true;
       }).overrideAttrs
         (oldAttrs: {
           postConfigure = ''


### PR DESCRIPTION
This used to be ignored by default on aarch64, but now unstable disables that behavior and the rpi config fails. This change has no effect on 24.11.