### PR TITLE
bump 6.6.y and 6.12.y kernel versions

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -58,8 +58,8 @@
         "rpi-bluez-firmware-src": "rpi-bluez-firmware-src",
         "rpi-firmware-nonfree-src": "rpi-firmware-nonfree-src",
         "rpi-firmware-src": "rpi-firmware-src",
-        "rpi-linux-6_12_11-src": "rpi-linux-6_12_11-src",
-        "rpi-linux-6_6_67-src": "rpi-linux-6_6_67-src",
+        "rpi-linux-6_12_17-src": "rpi-linux-6_12_17-src",
+        "rpi-linux-6_6_78-src": "rpi-linux-6_6_78-src",
         "rpi-linux-stable-src": "rpi-linux-stable-src",
         "rpicam-apps-src": "rpicam-apps-src"
       }
@@ -115,14 +115,14 @@
         "type": "github"
       }
     },
-    "rpi-linux-6_12_11-src": {
+    "rpi-linux-6_12_17-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1738149451,
-        "narHash": "sha256-NGmZcaC2vlewTEV/p0z2+6PWnHB229dkGui45kI8HOE=",
+        "lastModified": 1740765145,
+        "narHash": "sha256-hoCsGc4+RC/2LmxDtswLBL5ZhWlw4vSiL4Vkl39r2MU=",
         "owner": "raspberrypi",
         "repo": "linux",
-        "rev": "fab655ee33e6d647da5996c5548cfd7d43447a53",
+        "rev": "5985ce32e511f4e8279a841a1b06a8c7d972b386",
         "type": "github"
       },
       "original": {
@@ -132,14 +132,14 @@
         "type": "github"
       }
     },
-    "rpi-linux-6_6_67-src": {
+    "rpi-linux-6_6_78-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1734790986,
-        "narHash": "sha256-q9swM2TmmuzbUuQnbLZk5PseKWD7/SNPwtth6bpGIqE=",
+        "lastModified": 1740503700,
+        "narHash": "sha256-Y8+ot4Yi3UKwlZK3ap15rZZ16VZDvmeFkD46+6Ku7bE=",
         "owner": "raspberrypi",
         "repo": "linux",
-        "rev": "811ff707533bcd67cdcd368bbd46223082009b12",
+        "rev": "2e071057fded90e789c0101498e45a1778be93fe",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -7,11 +7,11 @@
       flake = false;
       url = "github:raspberrypi/linux/stable_20241008";
     };
-    rpi-linux-6_6_67-src = {
+    rpi-linux-6_6_78-src = {
       flake = false;
       url = "github:raspberrypi/linux/rpi-6.6.y";
     };
-    rpi-linux-6_12_11-src = {
+    rpi-linux-6_12_17-src = {
       flake = false;
       url = "github:raspberrypi/linux/rpi-6.12.y";
     };

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -1,6 +1,6 @@
 { rpi-linux-stable-src
-, rpi-linux-6_6_67-src
-, rpi-linux-6_12_11-src
+, rpi-linux-6_6_78-src
+, rpi-linux-6_12_17-src
 , rpi-firmware-src
 , rpi-firmware-nonfree-src
 , rpi-bluez-firmware-src
@@ -10,9 +10,9 @@ final: prev:
 let
   versions = {
     v6_6_51.src = rpi-linux-stable-src;
-    v6_6_67.src = rpi-linux-6_6_67-src;
-    v6_12_11 = {
-      src = rpi-linux-6_12_11-src;
+    v6_6_78.src = rpi-linux-6_6_78-src;
+    v6_12_17 = {
+      src = rpi-linux-6_12_17-src;
       patches = [
         {
           name = "remove-readme-target.patch";
@@ -114,7 +114,7 @@ in
   # rpi kernels and firmware are available at
   # `pkgs.rpi-kernels.<VERSION>.<BOARD>'. 
   #
-  # For example: `pkgs.rpi-kernels.v6_6_67.bcm2712'
+  # For example: `pkgs.rpi-kernels.v6_6_78.bcm2712'
   rpi-kernels = rpi-kernels (
     final.lib.cartesianProduct
       { board = boards; version = (builtins.attrNames versions); }


### PR DESCRIPTION
`rpi-6.6.y` went from `6.6.67` to `6.6.78`.
`rpi-6.12.y` went from `6.12.11` to `6.12.17`

A prerequisite for #128 